### PR TITLE
feat: Adding input list layout and styling as reusable template

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -40,5 +40,24 @@
         <div class="col board-col"></div>
       </div>
     </div>
+    <template id="move">
+      <div class="board-move">
+        <div class="reorder">
+          <svg class="up-arrow" viewBox="0 0 512 512" width="24px" height="24px" xmlns="http://www.w3.org/2000/svg" style="cursor: pointer">
+            <path d="M128.4,189.3L233.4,89c5.8-6,13.7-9,22.4-9c8.7,0,16.5,3,22.4,9l105.4,100.3c12.5,11.9,12.5,31.3,0,43.2  c-12.5,11.9-32.7,11.9-45.2,0L288,184.4v217c0,16.9-14.3,30.6-32,30.6c-17.7,0-32-13.7-32-30.6v-217l-50.4,48.2  c-12.5,11.9-32.7,11.9-45.2,0C115.9,220.6,115.9,201.3,128.4,189.3z"/>
+          </svg>
+          <svg class="down-arrow" viewBox="0 0 512 512" width="24px" height="24px" xmlns="http://www.w3.org/2000/svg" style="cursor: pointer">
+            <path d="M383.6,322.7L278.6,423c-5.8,6-13.7,9-22.4,9c-8.7,0-16.5-3-22.4-9L128.4,322.7c-12.5-11.9-12.5-31.3,0-43.2  c12.5-11.9,32.7-11.9,45.2,0l50.4,48.2v-217c0-16.9,14.3-30.6,32-30.6c17.7,0,32,13.7,32,30.6v217l50.4-48.2  c12.5-11.9,32.7-11.9,45.2,0C396.1,291.4,396.1,310.7,383.6,322.7z"/>
+          </svg>
+        </div>
+        <div class="move-input-container">
+          <input class="move-input" />
+          <div class="input-error"></div>
+        </div>
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024" x="0px" y="0px" class="delete">
+          <path fill="#000000" d="M736.1 886H286V372.8h-84V970h618.1V372.8h-84zM651.3 202.6V75H373.8v127.6H98v84h830v-84H651.3zM457.8 159h109.5v43.6H457.8V159zM373.8 373h84v408.6h-84zM567.3 372.8h84v408.5h-84z"/>
+        </svg>
+      </div>
+    </template>  
   </body>
 </html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -187,3 +187,51 @@ button.primary:hover {
 #start {
   margin-top: 15px;
 }
+
+.board-move {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  justify-content: flex-start;
+  margin: 0 1rem 0.3rem 1rem;
+  flex-grow: 1;
+}
+
+.reorder {
+  margin-right: 5px;
+  width: 48px;
+  display: flex;
+}
+
+.delete {
+  display: flex;
+  width: 21px;
+  height: 22px;
+  margin: 0 0.5rem 0 0.5rem;
+  cursor: pointer;
+}
+
+.move-input-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  flex-grow: 1;
+}
+
+.move-input {
+  display: flex;
+  width: 100%;
+  height: 1.2rem;
+}
+
+.input-error {
+  display: flex;
+  color: red;
+  width: 100%;
+  font-size: 12px;
+}
+
+input.invalid {
+  border: 1px solid red;
+}


### PR DESCRIPTION
Adds the input list template with the following features:
- Up/Down arrows to reorder the move among the list
- Input box for the user to enter the move into
- Validation message below the input box for when the user input does not match the format
- Delete icon to remove the move from the list

Ref: https://github.com/Svjard/chessplayback/issues/5