### PR TITLE
feat: Add support for clicking the import dialog cancel button

### DIFF
--- a/src/chessplayback.js
+++ b/src/chessplayback.js
@@ -9,4 +9,8 @@ export function initializeEvents(boardState) {
   document.getElementById('bulk-import').addEventListener('click', () => {
     document.getElementById('bulk-import-dialog').style.display = 'block';
   });
+
+  document.getElementById('bulk-import-cancel').addEventListener('click', () => {
+    document.getElementById('bulk-import-dialog').style.display = 'none';
+  });
 }

--- a/test/chessplayback.spec.js
+++ b/test/chessplayback.spec.js
@@ -59,12 +59,26 @@ describe('Chess Playback Tests', () => {
       sut.initializeEvents(boardState);
 
       expect(getElementByIdFn).toHaveBeenCalledWith('bulk-import');
-      expect(addEventListenerFn.mock.calls[0][0]).toEqual('click');
+      expect(addEventListenerFn.mock.calls[1][0]).toEqual('click');
 
       addEventListenerFn.mock.calls[1][1]();
 
       expect(getElementByIdFn).toHaveBeenCalledWith('bulk-import-dialog');
       expect(styleObj.display).toBe('block');
+    });
+
+    it('should setup event listener for clicking bulk import cancel button', () => {
+      boardState.moves = [];
+
+      sut.initializeEvents(boardState);
+
+      expect(getElementByIdFn).toHaveBeenCalledWith('bulk-import-cancel');
+      expect(addEventListenerFn.mock.calls[2][0]).toEqual('click');
+
+      addEventListenerFn.mock.calls[2][1]();
+
+      expect(getElementByIdFn).toHaveBeenCalledWith('bulk-import-dialog');
+      expect(styleObj.display).toBe('none');
     });
   });
 });


### PR DESCRIPTION
Provides logic for when the user clicks the Cancel button in the bulk import dialog to dismiss the dialog

Ref: https://github.com/Svjard/chessplayback/issues/24