### PR TITLE
feat: Add click handler and logic for processing the data from bulk import submit

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -129,6 +129,7 @@
           <path fill="#000000" d="M736.1 886H286V372.8h-84V970h618.1V372.8h-84zM651.3 202.6V75H373.8v127.6H98v84h830v-84H651.3zM457.8 159h109.5v43.6H457.8V159zM373.8 373h84v408.6h-84zM567.3 372.8h84v408.5h-84z"/>
         </svg>
       </div>
-    </template>  
+    </template>
+    <script src="./dist/bundle.js"></script>  
   </body>
 </html>

--- a/src/chessplayback.js
+++ b/src/chessplayback.js
@@ -13,4 +13,19 @@ export function initializeEvents(boardState) {
   document.getElementById('bulk-import-cancel').addEventListener('click', () => {
     document.getElementById('bulk-import-dialog').style.display = 'none';
   });
+
+  document.getElementById('bulk-import-import').addEventListener('click', () => {
+    const movesText = document.getElementById('bulk-import-moves').value;
+    if (!movesText.length) {
+      document.getElementById('bulk-import-moves').classList.add('invalid');
+      document.getElementById('import-error').style.display = 'flex';
+      return;
+    }
+
+    const moves = movesText.split('\n');
+
+    document.getElementById('bulk-import-dialog').style.display = 'none';
+      
+    boardState.moves.push(...moves.map(m => ({ value: m })));
+  });
 }


### PR DESCRIPTION
Provides logic for when the user clicks the Submit button in the bulk import dialog to validate the input and add to the board state.

Ref: https://github.com/Svjard/chessplayback/issues/26